### PR TITLE
Fix absence of last cell in table if it's empty

### DIFF
--- a/moemark.js
+++ b/moemark.js
@@ -459,7 +459,7 @@ Lexer.prototype.token = function(src, top, bq) {
         type: 'table',
         header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
         align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+        cells: cap[3].replace(/(?: +)?\n$/, '').split('\n')
       };
 
       for (i = 0; i < item.align.length; i++) {


### PR DESCRIPTION
A simple table triggers the bug. The last table cell is missing in rendered output.
```markdown
| Column | Column |
| ------ | ------ |
|        |        |

Lorem ipsum
```

This is an upstream issue, discussed in chjj/marked#693 and a patch is proposed in chjj/marked#697. The maintainers of marked has not responded yet so this fix is directly put here. I tested it in Moeditor with tests in the aforementioned upstream PR and it worked fine.

Hope this can be helpful. Happy Chinese new year :)